### PR TITLE
Replace UIEdgeInsetsInsetRect with CGRect.inset(by:)

### DIFF
--- a/TypingIndicator/TypingBubble.swift
+++ b/TypingIndicator/TypingBubble.swift
@@ -130,7 +130,7 @@ open class TypingBubble: UIView {
         contentBubble.layer.cornerRadius = contentBubbleFrameCornerRadius
             
         let insets = UIEdgeInsets(top: offset, left: contentBubbleFrameCornerRadius / 1.25, bottom: offset, right: contentBubbleFrameCornerRadius / 1.25)
-        typingIndicator.frame = UIEdgeInsetsInsetRect(contentBubble.bounds, insets)
+	typingIndicator.frame = contentBubble.bounds.inset(by: insets)
     }
     
     // MARK: - Animation API


### PR DESCRIPTION
Swift 4.2 raise error for `UIEdgeInsetsInsetRect`.
`UIEdgeInsetsInsetRect` has been replaced by instance method `CGRect.inset(by:)`